### PR TITLE
Fix broken link to github (by fixing page title).

### DIFF
--- a/site/jquery.richTooltip.md
+++ b/site/jquery.richTooltip.md
@@ -1,11 +1,11 @@
 ---
 layout: main
-title: jquery.richTooltips
+title: jquery.richTooltip
 ---
 
-## jQuery.richTooltips
+## jQuery.richTooltip
 
-jQuery.richTooltips is a tooltip replacement which, unlike traditional tooltips, is designed to work on both desktop and touch/mobile devices. 
+jQuery.richTooltip is a tooltip replacement which, unlike traditional tooltips, is designed to work on both desktop and touch/mobile devices. 
 
 ### Usage
 


### PR DESCRIPTION
The title is also used to create the link to the source code on Github, so that link is broken, since the actual name of the plugin file doesn't end with the "s".
